### PR TITLE
Adds support for quoted selectors containing reserved characters and white space

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,7 +70,7 @@ It can be any non empty Unicode string that doesn’t contain reserved character
 The specific syntax of the selector is not enforced by this parser.
 
 ----
-selector       = unreserved-str;
+selector       = unreserved-str | double-quoted | single-quoted;
 ----
 
 Comparison operators are in FIQL notation and some of them has an alternative syntax as well:

--- a/src/main/javacc/RSQLParser.jj
+++ b/src/main/javacc/RSQLParser.jj
@@ -183,9 +183,11 @@ ComparisonNode Comparison():
 
 String Selector(): {}
 {
-    token = <UNRESERVED_STR>
+    token = <UNRESERVED_STR> { return token.image; }
+    |
+    ( token = <DOUBLE_QUOTED_STR> | token = <SINGLE_QUOTED_STR> )
     {
-        return token.image;
+        return unescape(token.image);
     }
 }
 

--- a/src/test/groovy/cz/jirutka/rsql/parser/RSQLParserTest.groovy
+++ b/src/test/groovy/cz/jirutka/rsql/parser/RSQLParserTest.groovy
@@ -87,7 +87,16 @@ class RSQLParserTest extends Specification {
                 'allons-y', 'l00k.dot.path', 'look/XML/path', 'n:look/n:xml', 'path.to::Ref', '$doll_r.way' ]
     }
 
-    def 'throw exception for selector with reserved char: #input'() {
+    def 'parse quoted selector with any chars: #input'() {
+        given:
+            def expected = eq(input[1..-2], 'val')
+        expect:
+            parse("${input}==val") == expected
+        where:
+            input << [ '"hi there!"', "'Pěkný den!'", '"Flynn\'s *"', '"o)\'O\'(o"', '"6*7=42"' ]
+    }
+
+    def 'throw exception for selector with unquoted reserved char: #input'() {
         when:
             parse("${input}==val")
         then:


### PR DESCRIPTION
Resolves #4 

Allows queries like: `"Movie Title" == TRON`

This is taken partially from: https://github.com/jirutka/rsql-parser/pull/36, with some fixes and added tests.